### PR TITLE
Step4: 같은 사용자가 동일 특강 신청하지 못하도록 개선, 1번만 신청 성공하는 통합 테스트 작성

### DIFF
--- a/src/main/java/io/hhplus/education/infra/repository/LectureRegistrationJpaRepository.java
+++ b/src/main/java/io/hhplus/education/infra/repository/LectureRegistrationJpaRepository.java
@@ -1,7 +1,9 @@
 package io.hhplus.education.infra.repository;
 
 import io.hhplus.education.infra.entity.LectureRegistration;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 
 import java.util.List;
 import java.util.Optional;
@@ -10,5 +12,6 @@ public interface LectureRegistrationJpaRepository extends JpaRepository<LectureR
 
     List<LectureRegistration> findByStudentId(Long studentId);
 
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
     Optional<LectureRegistration> findByLectureScheduleIdAndStudentId(Long lectureScheduleId, Long studentId);
 }

--- a/src/test/java/io/hhplus/education/application/facade/LectureFacadeTest.java
+++ b/src/test/java/io/hhplus/education/application/facade/LectureFacadeTest.java
@@ -1,7 +1,7 @@
 package io.hhplus.education.application.facade;
 
-import io.hhplus.education.application.domain.service.LectureService;
 import io.hhplus.education.infra.entity.Lecture;
+import io.hhplus.education.infra.entity.LectureRegistration;
 import io.hhplus.education.infra.entity.LectureSchedule;
 import io.hhplus.education.infra.repository.LectureJpaRepository;
 import io.hhplus.education.infra.repository.LectureScheduleJpaRepository;
@@ -66,7 +66,7 @@ public class LectureFacadeTest {
         List<Callable<Boolean>> tasks = new ArrayList<>();
 
         for (int i = 0; i < concurrentRequests; i++) {
-            Long testUserId = (long)i;
+            Long testUserId = (long) i;
             tasks.add(() -> {
                 try {
                     LectureRequestDto requestDto = new LectureRequestDto(lecture.getId(), lectureSchedule.getId(), testUserId);
@@ -90,4 +90,27 @@ public class LectureFacadeTest {
 
         assertEquals(30, successfulRegistrations);
     }
+
+    @Test
+    @DisplayName("같은 사용자가 동일 특강에 대해 1번만 신청 성공하는 테스트")
+    void allowSingleRegistrationPerUser() {
+
+        int tryCount = 5;
+        int successCount = 0;
+        int failCount = 0;
+
+        for (int i = 0; i < tryCount; i++) {
+            try {
+                LectureRequestDto requestDto = new LectureRequestDto(lecture.getId(), lectureSchedule.getId(), 1L);
+                lectureFacade.registerLecture(requestDto);
+                successCount++;
+            } catch (RuntimeException e) {
+                failCount++;
+            }
+        }
+
+        assertEquals(1, successCount);
+        assertEquals(4, failCount);
+    }
 }
+


### PR DESCRIPTION
## 작업내용
- 이미 신청한 특강 조회 시 비관적 락 기능 추가
- 동일한 유저 정보로 같은 특강을 5번 신청했을 때, 1번만 성공하는 것을 검증하는 **통합 테스트** 작성